### PR TITLE
feat: implement custom entrypoint script for WordPress setup tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 **/*.tar
 **/*.zip
 **/*.tar.gz
+/.vscode/settings.json

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,17 +19,7 @@ services:
     volumes:
       - wordpress_data:/var/www/html
       - ./themes/${ACTIVE_THEME}:/var/www/html/wp-content/themes/${ACTIVE_THEME}
-    command: >
-      bash -c "
-        # Instalar plugins requeridos (no falla si WP aún no está instalado)
-        /usr/local/bin/install-required-plugins.sh || true &&
-        if [ -n \"$$ACTIVE_THEME\" ] && [ -f \"/var/www/html/wp-content/themes/$$ACTIVE_THEME/composer.json\" ]; then
-          echo '📦 Instalando dependencias de Composer para tema:' $$ACTIVE_THEME &&
-          cd /var/www/html/wp-content/themes/$$ACTIVE_THEME &&
-          composer install --no-dev --optimize-autoloader;
-        fi &&
-        apache2-foreground
-      "
+    # Startup tasks moved to image entrypoint: docker/scripts/wp-entrypoint.sh
     depends_on:
       - db
 

--- a/docker/scripts/wp-entrypoint.sh
+++ b/docker/scripts/wp-entrypoint.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Preserve original WordPress entrypoint path
+ORIG_ENTRYPOINT="/usr/local/bin/docker-entrypoint.sh"
+
+# Ensure original entrypoint exists
+if [ ! -x "$ORIG_ENTRYPOINT" ]; then
+  echo "Original WordPress entrypoint not found at $ORIG_ENTRYPOINT" >&2
+  exit 1
+fi
+
+# Informative banner
+echo "➡️  wp-entrypoint: starting pre-start tasks"
+
+# Install required plugins (won't fail if WP not installed yet)
+if command -v install-required-plugins.sh >/dev/null 2>&1; then
+  echo "🔌 Checking and installing required plugins (best-effort)"
+  /usr/local/bin/install-required-plugins.sh || true
+fi
+
+# Install Composer dependencies for the active theme if present
+ACTIVE_THEME=${ACTIVE_THEME:-}
+if [ -n "$ACTIVE_THEME" ]; then
+  THEME_DIR="/var/www/html/wp-content/themes/$ACTIVE_THEME"
+  if [ -f "$THEME_DIR/composer.json" ]; then
+    echo "📦 Installing Composer dependencies for theme: $ACTIVE_THEME"
+    (cd "$THEME_DIR" && composer install --no-dev --optimize-autoloader) || true
+  else
+    echo "ℹ️  No composer.json found for theme: $ACTIVE_THEME"
+  fi
+else
+  echo "ℹ️  ACTIVE_THEME not set; skipping theme dependency installation"
+fi
+
+# Hand off to the original WordPress entrypoint with received args
+echo "➡️  wp-entrypoint: handing off to WordPress entrypoint"
+exec "$ORIG_ENTRYPOINT" "$@"

--- a/docker/wordpress/Dockerfile
+++ b/docker/wordpress/Dockerfile
@@ -7,8 +7,6 @@ RUN chmod +x /tmp/install-system-dependencies.sh && /tmp/install-system-dependen
 # Optional: allow WP-CLI as root without warnings
 ENV WP_CLI_ALLOW_ROOT=1
 
-# (Plugins pre-install removed) Keeping image lean and runtime-driven
-
 # Script to install Composer dependencies in the active theme
 COPY docker/scripts/install-theme-dependencies.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-theme-dependencies.sh
@@ -16,3 +14,10 @@ RUN chmod +x /usr/local/bin/install-theme-dependencies.sh
 # Script to install required plugins from the active theme JSON
 COPY docker/scripts/install-required-plugins.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-required-plugins.sh
+
+# Custom entrypoint to run setup tasks and then start Apache
+COPY docker/scripts/wp-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/wp-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/wp-entrypoint.sh"]
+CMD ["apache2-foreground"]


### PR DESCRIPTION
This pull request refactors how WordPress container startup tasks are handled, moving pre-start setup logic out of the `docker-compose.yaml` command and into a dedicated entrypoint script. This makes the startup process more modular, maintainable, and easier to extend. The most important changes are grouped below:

**Entrypoint Refactor and Container Startup**

* Added a new script `docker/scripts/wp-entrypoint.sh` that runs pre-start tasks (plugin installation, theme Composer dependencies) before handing off to the original WordPress entrypoint. This replaces the inline shell logic previously in `docker-compose.yaml`.
* Updated `docker/wordpress/Dockerfile` to use the new entrypoint script, ensuring it is executable and set as the container's entrypoint. The default command remains unchanged (`apache2-foreground`).

**Configuration Cleanup**

* Removed the multi-line `command` section from the WordPress service in `docker-compose.yaml`, since startup logic is now encapsulated in the entrypoint script.